### PR TITLE
Fixed a critical translation problem

### DIFF
--- a/addon/appModules/splstudio/splbase.py
+++ b/addon/appModules/splstudio/splbase.py
@@ -7,6 +7,8 @@
 import ui
 from winUser import sendMessage, user32
 from .spldebugging import debugOutput
+import addonHandler
+addonHandler.initTranslation()
 
 # Cache the handle to main Studio window.
 _SPLWin = None

--- a/addon/appModules/splstudio/splconfig.py
+++ b/addon/appModules/splstudio/splconfig.py
@@ -27,6 +27,9 @@ import globalVars
 import ui
 import gui
 import wx
+import addonHandler
+addonHandler.initTranslation()
+
 # #50 (18.03): keep an eye on update check facility.
 try:
 	from . import splupdate

--- a/addon/appModules/splstudio/splconfui.py
+++ b/addon/appModules/splstudio/splconfui.py
@@ -28,6 +28,8 @@ try:
 	from . import splupdate
 except RuntimeError:
 	splupdate = None
+import addonHandler
+addonHandler.initTranslation()
 from . import splconfig
 from . import splactions
 

--- a/addon/appModules/splstudio/splmisc.py
+++ b/addon/appModules/splstudio/splmisc.py
@@ -13,6 +13,8 @@ from _csv import reader # For cart explorer.
 import gui
 import wx
 import ui
+import addonHandler
+addonHandler.initTranslation()
 from winUser import user32
 from . import splbase
 from .spldebugging import debugOutput

--- a/addon/appModules/splstudio/splupdate.py
+++ b/addon/appModules/splstudio/splupdate.py
@@ -28,6 +28,7 @@ import config
 if config.isAppX:
 	raise RuntimeError("This is NVDA Windows Store edition")
 import addonHandler
+addonHandler.initTranslation()
 # Provided that NVDA issue 3208 is implemented.
 if hasattr(addonHandler, "checkForAddonUpdate"):
 	raise RuntimeError("NVDA itself will check for add-on updates")

--- a/addon/globalPlugins/splUtils/encoders.py
+++ b/addon/globalPlugins/splUtils/encoders.py
@@ -14,6 +14,8 @@ import winUser
 import tones
 import gui
 import wx
+import addonHandler
+addonHandler.initTranslation()
 
 # SPL Studio uses WM messages to send and receive data, similar to Winamp (see NVDA sources/appModules/winamp.py for more information).
 user32 = winUser.user32 # user32.dll.


### PR DESCRIPTION
Hi Joseph.
Recently, a spanish community member has reported that the add-on shows messages and dialogs in english, despite NVDA is in spanish and the translation is included. After a short code review, I have discovered where the problem is. So far, this pull request contains only a commit which adds addonHandler.initTranslation() on six modules where it was missing. This function must be called on each module which contains translatable strings. Now, all add-on translations should work as expected.
Regards.