### PR TITLE
Fixed 166 issues of type: PYTHON_E225 throughout 10 files in repo.

### DIFF
--- a/addon/appModules/splcreator.py
+++ b/addon/appModules/splcreator.py
@@ -60,7 +60,7 @@ class SPLCreatorItem(SPLTrackItem):
 	def exploreColumns(self):
 		return splconfig.SPLConfig["General"]["ExploreColumnsCreator"]
 
-	__gestures={
+	__gestures = {
 		"kb:control+alt+downArrow": None,
 		"kb:control+alt+upArrow": None,
 	}

--- a/addon/appModules/splengine.py
+++ b/addon/appModules/splengine.py
@@ -7,7 +7,7 @@ import appModuleHandler
 import controlTypes
 
 # For SPL encoder config screen at least, control iD's are different, which allows labels to be generated easily.
-encoderSettingsLabels= {
+encoderSettingsLabels = {
 	1008: "Quality",
 	1009: "Sample Rate",
 	1010: "Channels",

--- a/addon/appModules/splstreamer.py
+++ b/addon/appModules/splstreamer.py
@@ -10,7 +10,7 @@ import controlTypes
 from NVDAObjects.IAccessible import IAccessible
 
 # For SPL encoder config screen at least, control iD's are different, which allows labels to be generated easily.
-encoderSettingsLabels= {
+encoderSettingsLabels = {
 	1008: "Quality",
 	1009: "Sample Rate",
 	1010: "Channels",

--- a/addon/appModules/splstudio/__init__.py
+++ b/addon/appModules/splstudio/__init__.py
@@ -111,14 +111,14 @@ class SPLTrackItem(sysListView32.ListItem):
 		if (self._curColumnNumber+1) == self.parent.columnCount:
 			tones.beep(2000, 100)
 		else:
-			self.__class__._curColumnNumber +=1
+			self.__class__._curColumnNumber += 1
 		self.announceColumnContent(self._curColumnNumber)
 
 	def script_moveToPreviousColumn(self, gesture):
 		if self._curColumnNumber <= 0:
 			tones.beep(2000, 100)
 		else:
-			self.__class__._curColumnNumber -=1
+			self.__class__._curColumnNumber -= 1
 		self.announceColumnContent(self._curColumnNumber)
 
 	def script_firstColumn(self, gesture):
@@ -156,7 +156,7 @@ class SPLTrackItem(sysListView32.ListItem):
 			# Translators: Presented when a specific column header is not found.
 			ui.message(_("{headerText} not found").format(headerText = header))
 
-	__gestures={
+	__gestures = {
 		"kb:control+alt+home":"firstColumn",
 		"kb:control+alt+end":"lastColumn",
 	}
@@ -275,7 +275,7 @@ class SPLStudioTrackItem(SPLTrackItem):
 		if self._curColumnNumber <= 0:
 			tones.beep(2000, 100)
 		else:
-			self.__class__._curColumnNumber -=1
+			self.__class__._curColumnNumber -= 1
 		if self._curColumnNumber == 0:
 			self._leftmostcol()
 		else:
@@ -392,7 +392,7 @@ class SPLStudioTrackItem(SPLTrackItem):
 	# Translators: Input help message for track comment announcemnet command in SPL Studio.
 	script_announceTrackComment.__doc__ = _("Announces track comment if any. Press twice to copy this information to the clipboard, and press three times to open a dialog to add, change or remove track comments")
 
-	__gestures={
+	__gestures = {
 		"kb:downArrow":"nextTrack",
 		"kb:upArrow":"prevTrack",
 		"kb:control+NVDA+-":"trackColumnsViewer",
@@ -425,9 +425,9 @@ class SPL510TrackItem(SPLStudioTrackItem):
 			# Translators: Status information for a checked track in Studio 5.10.
 			ui.message(_("Status: {name}").format(name = self.name))
 
-	__gestures={"kb:space":"select"}
+	__gestures = {"kb:space":"select"}
 
-SPLAssistantHelp={
+SPLAssistantHelp = {
 	# Translators: The text of the help command in SPL Assistant layer.
 	"off":_("""After entering SPL Assistant, press:
 A: Automation.
@@ -546,14 +546,14 @@ class ReversedDialog(Dialog):
 		@param allowFocusedDescendants: if false no text will be returned at all if one of the descendants is focused.
 		@type allowFocusedDescendants: boolean
 		"""
-		children=obj.children
-		textList=[]
-		childCount=len(children)
+		children = obj.children
+		textList = []
+		childCount = len(children)
 		# For these dialogs, children are arranged in reverse tab order (very strange indeed).
 		for index in six.moves.range(childCount-1, -1, -1):
-			child=children[index]
-			childStates=child.states
-			childRole=child.role
+			child = children[index]
+			childStates = child.states
+			childRole = child.role
 			#We don't want to handle invisible or unavailable objects
 			if controlTypes.STATE_INVISIBLE in childStates or controlTypes.STATE_UNAVAILABLE in childStates:
 				continue
@@ -561,7 +561,7 @@ class ReversedDialog(Dialog):
 			if childRole in (controlTypes.ROLE_PROPERTYPAGE,controlTypes.ROLE_PANE,controlTypes.ROLE_PANEL,controlTypes.ROLE_WINDOW,controlTypes.ROLE_GROUPING,controlTypes.ROLE_PARAGRAPH,controlTypes.ROLE_SECTION,controlTypes.ROLE_TEXTFRAME,controlTypes.ROLE_UNKNOWN):
 				#Grab text from descendants, but not for a child which inherits from Dialog and has focusable descendants
 				#Stops double reporting when focus is in a property page in a dialog
-				childText=cls.getDialogText(child,not isinstance(child,Dialog))
+				childText = cls.getDialogText(child,not isinstance(child,Dialog))
 				if childText:
 					textList.append(childText)
 				elif childText is None:
@@ -575,24 +575,24 @@ class ReversedDialog(Dialog):
 				 # Static text, labels and links
 				 childRole in (controlTypes.ROLE_STATICTEXT,controlTypes.ROLE_LABEL,controlTypes.ROLE_LINK)
 				# Read-only, non-multiline edit fields
-				or (childRole==controlTypes.ROLE_EDITABLETEXT and controlTypes.STATE_READONLY in childStates and controlTypes.STATE_MULTILINE not in childStates)
+				or (childRole == controlTypes.ROLE_EDITABLETEXT and controlTypes.STATE_READONLY in childStates and controlTypes.STATE_MULTILINE not in childStates)
 			):
 				continue
 			#We should ignore a text object directly after a grouping object, as it's probably the grouping's description
-			if index>0 and children[index-1].role==controlTypes.ROLE_GROUPING:
+			if index > 0 and children[index-1].role == controlTypes.ROLE_GROUPING:
 				continue
 			#Like the last one, but a graphic might be before the grouping's description
-			if index>1 and children[index-1].role==controlTypes.ROLE_GRAPHIC and children[index-2].role==controlTypes.ROLE_GROUPING:
+			if index > 1 and children[index-1].role == controlTypes.ROLE_GRAPHIC and children[index-2].role == controlTypes.ROLE_GROUPING:
 				continue
-			childName=child.name
-			if childName and index<(childCount-1) and children[index+1].role not in (controlTypes.ROLE_GRAPHIC,controlTypes.ROLE_STATICTEXT,controlTypes.ROLE_SEPARATOR,controlTypes.ROLE_WINDOW,controlTypes.ROLE_PANE,controlTypes.ROLE_BUTTON) and children[index+1].name==childName:
+			childName = child.name
+			if childName and index < (childCount-1) and children[index+1].role not in (controlTypes.ROLE_GRAPHIC,controlTypes.ROLE_STATICTEXT,controlTypes.ROLE_SEPARATOR,controlTypes.ROLE_WINDOW,controlTypes.ROLE_PANE,controlTypes.ROLE_BUTTON) and children[index+1].name == childName:
 				# This is almost certainly the label for the next object, so skip it.
 				continue
-			isNameIncluded=child.TextInfo is NVDAObjectTextInfo or childRole in (controlTypes.ROLE_LABEL,controlTypes.ROLE_STATICTEXT)
-			childText=child.makeTextInfo(textInfos.POSITION_ALL).text
+			isNameIncluded = child.TextInfo is NVDAObjectTextInfo or childRole in (controlTypes.ROLE_LABEL,controlTypes.ROLE_STATICTEXT)
+			childText = child.makeTextInfo(textInfos.POSITION_ALL).text
 			if not childText or childText.isspace() and child.TextInfo is not NVDAObjectTextInfo:
-				childText=child.basicText
-				isNameIncluded=True
+				childText = child.basicText
+				isNameIncluded = True
 			if not isNameIncluded:
 				# The label isn't in the text, so explicitly include it first.
 				if childName:
@@ -608,18 +608,18 @@ class SPLTimePicker(IAccessible):
 	def script_changeTimePickerValue(self, gesture):
 		gesture.send()
 		import treeInterceptorHandler
-		obj=api.getFocusObject()
-		treeInterceptor=obj.treeInterceptor
+		obj = api.getFocusObject()
+		treeInterceptor = obj.treeInterceptor
 		if isinstance(treeInterceptor,treeInterceptorHandler.DocumentTreeInterceptor) and not treeInterceptor.passThrough:
-			obj=treeInterceptor
+			obj = treeInterceptor
 		try:
-			info=obj.makeTextInfo(textInfos.POSITION_CARET)
+			info = obj.makeTextInfo(textInfos.POSITION_CARET)
 		except (NotImplementedError, RuntimeError):
-			info=obj.makeTextInfo(textInfos.POSITION_FIRST)
+			info = obj.makeTextInfo(textInfos.POSITION_FIRST)
 		info.expand(textInfos.UNIT_LINE)
 		speech.speakTextInfo(info,unit=textInfos.UNIT_LINE,reason=controlTypes.REASON_CARET)
 
-	__gestures={
+	__gestures = {
 		"kb:upArrow":"changeTimePickerValue",
 		"kb:downArrow":"changeTimePickerValue"
 	}
@@ -681,7 +681,7 @@ class AppModule(appModuleHandler.AppModule):
 		self.noMoreHandle = threading.Event()
 		debugOutput("locating Studio window handle")
 		# If this is started right away, foreground and focus objects will be NULL according to NVDA if NVDA restarts while Studio is running.
-		t= threading.Thread(target=self._locateSPLHwnd)
+		t = threading.Thread(target=self._locateSPLHwnd)
 		wx.CallAfter(t.start)
 		# Display startup dialogs if any.
 		# 17.10: not when minimal startup flag is set.
@@ -853,7 +853,7 @@ class AppModule(appModuleHandler.AppModule):
 				elif "Loading" in obj.name:
 					if splconfig.SPLConfig["General"]["LibraryScanAnnounce"] not in ("off", "ending"):
 						# If library scan is in progress, announce its progress when told to do so.
-						self.scanCount+=1
+						self.scanCount += 1
 						if self.scanCount%100 == 0:
 							self._libraryScanAnnouncer(obj.name[1:obj.name.find("]")], splconfig.SPLConfig["General"]["LibraryScanAnnounce"])
 					if not self.libraryScanning:
@@ -1134,12 +1134,12 @@ class AppModule(appModuleHandler.AppModule):
 	def script_sayRemainingTime(self, gesture):
 		if splbase.studioIsRunning(): self.announceTime(splbase.studioAPI(3, 105), offset=1)
 	# Translators: Input help mode message for a command in Station Playlist Studio.
-	script_sayRemainingTime.__doc__=_("Announces the remaining track time.")
+	script_sayRemainingTime.__doc__ = _("Announces the remaining track time.")
 
 	def script_sayElapsedTime(self, gesture):
 		if splbase.studioIsRunning(): self.announceTime(splbase.studioAPI(0, 105))
 	# Translators: Input help mode message for a command in Station Playlist Studio.
-	script_sayElapsedTime.__doc__=_("Announces the elapsed time for the currently playing track.")
+	script_sayElapsedTime.__doc__ = _("Announces the elapsed time for the currently playing track.")
 
 	def script_sayBroadcasterTime(self, gesture):
 		if not splbase.studioIsRunning(): return
@@ -1154,11 +1154,11 @@ class AppModule(appModuleHandler.AppModule):
 			if h not in (0, 12):
 				h %= 12
 			if m == 0:
-				if h == 0: h+=12
+				if h == 0: h += 12
 				# Messages in this method should not be translated.
 				ui.message("{hour} o'clock".format(hour = h))
 			elif 1 <= m <= 30:
-				if h == 0: h+=12
+				if h == 0: h += 12
 				ui.message("{minute} min past {hour}".format(minute = m, hour = h))
 			else:
 				if h == 12: h = 1
@@ -1167,7 +1167,7 @@ class AppModule(appModuleHandler.AppModule):
 		else:
 			self.announceTime(3600-(m*60+localtime[5]), ms=False)
 	# Translators: Input help mode message for a command in Station Playlist Studio.
-	script_sayBroadcasterTime.__doc__=_("Announces broadcaster time. If pressed twice, reports minutes and seconds left to top of the hour.")
+	script_sayBroadcasterTime.__doc__ = _("Announces broadcaster time. If pressed twice, reports minutes and seconds left to top of the hour.")
 
 	def script_sayCompleteTime(self, gesture):
 		if not splbase.studioIsRunning(): return
@@ -1175,7 +1175,7 @@ class AppModule(appModuleHandler.AppModule):
 		# Says complete time in hours, minutes and seconds via kernel32's routines.
 		ui.message(winKernel.GetTimeFormat(winKernel.LOCALE_USER_DEFAULT, 0, None, None))
 	# Translators: Input help mode message for a command in Station Playlist Studio.
-	script_sayCompleteTime.__doc__=_("Announces time including seconds.")
+	script_sayCompleteTime.__doc__ = _("Announces time including seconds.")
 
 	# Invoke the common alarm dialog.
 	# The below invocation function is also used for error handling purposes.
@@ -1201,14 +1201,14 @@ class AppModule(appModuleHandler.AppModule):
 	def script_setEndOfTrackTime(self, gesture):
 		self.alarmDialog(1)
 	# Translators: Input help mode message for a command in Station Playlist Studio.
-	script_setEndOfTrackTime.__doc__=_("Sets end of track alarm (default is 5 seconds).")
+	script_setEndOfTrackTime.__doc__ = _("Sets end of track alarm (default is 5 seconds).")
 
 	# Set song ramp (introduction) time between 1 and 9 seconds.
 
 	def script_setSongRampTime(self, gesture):
 		self.alarmDialog(2)
 	# Translators: Input help mode message for a command in Station Playlist Studio.
-	script_setSongRampTime.__doc__=_("Sets song intro alarm (default is 5 seconds).")
+	script_setSongRampTime.__doc__ = _("Sets song intro alarm (default is 5 seconds).")
 
 	# Tell NVDA to play a sound when mic was active for a long time, as well as contorl the alarm interval.
 	# 8.0: This dialog will let users configure mic alarm interval as well.
@@ -1216,21 +1216,21 @@ class AppModule(appModuleHandler.AppModule):
 	def script_setMicAlarm(self, gesture):
 		self.alarmDialog(3)
 	# Translators: Input help mode message for a command in Station Playlist Studio.
-	script_setMicAlarm.__doc__=_("Sets microphone alarm (default is 5 seconds).")
+	script_setMicAlarm.__doc__ = _("Sets microphone alarm (default is 5 seconds).")
 
 	# SPL Config management among others.
 
 	def script_openConfigDialog(self, gesture):
 		wx.CallAfter(splconfui.onConfigDialog, None)
 	# Translators: Input help mode message for a command in Station Playlist Studio.
-	script_openConfigDialog.__doc__=_("Opens SPL Studio add-on configuration dialog.")
+	script_openConfigDialog.__doc__ = _("Opens SPL Studio add-on configuration dialog.")
 
 	def script_openWelcomeDialog(self, gesture):
 		gui.mainFrame.prePopup()
 		splconfig.WelcomeDialog(gui.mainFrame).Show()
 		gui.mainFrame.postPopup()
 	# Translators: Input help mode message for a command in Station Playlist Studio.
-	script_openWelcomeDialog.__doc__=_("Opens SPL Studio add-on welcome dialog.")
+	script_openWelcomeDialog.__doc__ = _("Opens SPL Studio add-on welcome dialog.")
 
 	# Other commands (track finder and others)
 
@@ -1250,7 +1250,7 @@ class AppModule(appModuleHandler.AppModule):
 		splconfig.SPLConfig["General"]["BrailleTimer"] = brailleTimer
 		splconfig.message("BrailleTimer", brailleTimer)
 	# Translators: Input help mode message for a command in Station Playlist Studio.
-	script_setBrailleTimer.__doc__=_("Toggles between various braille timer settings.")
+	script_setBrailleTimer.__doc__ = _("Toggles between various braille timer settings.")
 
 	# The track finder utility for find track script and other functions
 	# Perform a linear search to locate the track name and/or description which matches the entered value.
@@ -1345,12 +1345,12 @@ class AppModule(appModuleHandler.AppModule):
 	def script_findTrack(self, gesture):
 		if self._trackFinderCheck(0): self.trackFinderGUI()
 	# Translators: Input help mode message for a command in Station Playlist Studio.
-	script_findTrack.__doc__=_("Finds a track in the track list.")
+	script_findTrack.__doc__ = _("Finds a track in the track list.")
 
 	def script_columnSearch(self, gesture):
 		if self._trackFinderCheck(1): self.trackFinderGUI(columnSearch=True)
 	# Translators: Input help mode message for a command in Station Playlist Studio.
-	script_columnSearch.__doc__=_("Finds text in columns.")
+	script_columnSearch.__doc__ = _("Finds text in columns.")
 
 	# Find next and previous scripts.
 
@@ -1363,7 +1363,7 @@ class AppModule(appModuleHandler.AppModule):
 					startObj = startObj.firstChild
 				self.trackFinder(self.findText[0], obj=startObj.next)
 	# Translators: Input help mode message for a command in Station Playlist Studio.
-	script_findTrackNext.__doc__=_("Finds the next occurrence of the track with the name in the track list.")
+	script_findTrackNext.__doc__ = _("Finds the next occurrence of the track with the name in the track list.")
 
 	def script_findTrackPrevious(self, gesture):
 		if self._trackFinderCheck(0):
@@ -1374,7 +1374,7 @@ class AppModule(appModuleHandler.AppModule):
 					startObj = startObj.lastChild
 				self.trackFinder(self.findText[0], obj=startObj.previous, directionForward=False)
 	# Translators: Input help mode message for a command in Station Playlist Studio.
-	script_findTrackPrevious.__doc__=_("Finds previous occurrence of the track with the name in the track list.")
+	script_findTrackPrevious.__doc__ = _("Finds previous occurrence of the track with the name in the track list.")
 
 	# Time range finder.
 	# Locate a track with duration falling between min and max.
@@ -1391,7 +1391,7 @@ class AppModule(appModuleHandler.AppModule):
 			except RuntimeError:
 				wx.CallAfter(splmisc._finderError)
 	# Translators: Input help mode message for a command in Station Playlist Studio.
-	script_timeRangeFinder.__doc__=_("Locates track with duration within a time range")
+	script_timeRangeFinder.__doc__ = _("Locates track with duration within a time range")
 
 	# Cart explorer
 	cartExplorer = False
@@ -1451,7 +1451,7 @@ class AppModule(appModuleHandler.AppModule):
 			# Translators: Presented when cart explorer is off.
 			ui.message(_("Exiting cart explorer"))
 	# Translators: Input help mode message for a command in Station Playlist Studio.
-	script_toggleCartExplorer.__doc__=_("Toggles cart explorer to learn cart assignments.")
+	script_toggleCartExplorer.__doc__ = _("Toggles cart explorer to learn cart assignments.")
 
 	def script_cartExplorer(self, gesture):
 		if api.getForegroundObject().windowClassName != "TStudioForm":
@@ -1483,7 +1483,7 @@ class AppModule(appModuleHandler.AppModule):
 		splconfig.SPLConfig["General"]["LibraryScanAnnounce"] = libraryScanAnnounce
 		splconfig.message("LibraryScanAnnounce", libraryScanAnnounce)
 	# Translators: Input help mode message for a command in Station Playlist Studio.
-	script_setLibraryScanProgress.__doc__=_("Toggles library scan progress settings.")
+	script_setLibraryScanProgress.__doc__ = _("Toggles library scan progress settings.")
 
 	def script_startScanFromInsertTracks(self, gesture):
 		gesture.send()
@@ -1529,7 +1529,7 @@ class AppModule(appModuleHandler.AppModule):
 			scanCount = splbase.studioAPI(1, 32)
 			if scanCount < 0:
 				break
-			scanIter+=1
+			scanIter += 1
 			if scanIter%5 == 0 and splconfig.SPLConfig["General"]["LibraryScanAnnounce"] not in ("off", "ending"):
 				self._libraryScanAnnouncer(scanCount, splconfig.SPLConfig["General"]["LibraryScanAnnounce"])
 		self.libraryScanning = False
@@ -1598,7 +1598,7 @@ class AppModule(appModuleHandler.AppModule):
 		except RuntimeError:
 			wx.CallAfter(splconfig._alarmError)
 	# Translators: Input help mode message for a command in Station Playlist Studio.
-	script_manageMetadataStreams.__doc__=_("Opens a dialog to quickly enable or disable metadata streaming.")
+	script_manageMetadataStreams.__doc__ = _("Opens a dialog to quickly enable or disable metadata streaming.")
 
 	# Playlist Analyzer
 	# These include track time analysis, playlist snapshots, and some form of playlist transcripts and others.
@@ -1687,7 +1687,7 @@ class AppModule(appModuleHandler.AppModule):
 		else:
 			for track in six.moves.range(start, end+1):
 				filename = splbase.studioAPI(track, 211)
-				totalLength+=splbase.studioAPI(filename, 30)
+				totalLength += splbase.studioAPI(filename, 30)
 		return totalLength
 
 	# Playlist snapshots
@@ -1859,7 +1859,7 @@ class AppModule(appModuleHandler.AppModule):
 	# The developer would like to get feedback from you.
 	def script_sendFeedbackEmail(self, gesture):
 		os.startfile("mailto:joseph.lee22590@gmail.com")
-	script_sendFeedbackEmail.__doc__="Opens the default email client to send an email to the add-on developer"
+	script_sendFeedbackEmail.__doc__ = "Opens the default email client to send an email to the add-on developer"
 
 	# SPL Assistant: reports status on playback, operation, etc.
 	# Used layer command approach to save gesture assignments.
@@ -1930,7 +1930,7 @@ class AppModule(appModuleHandler.AppModule):
 		except WindowsError:
 			return
 	# Translators: Input help mode message for a layer command in Station Playlist Studio.
-	script_SPLAssistantToggle.__doc__=_("The SPL Assistant layer command. See the add-on guide for more information on available commands.")
+	script_SPLAssistantToggle.__doc__ = _("The SPL Assistant layer command. See the add-on guide for more information on available commands.")
 
 	# Status table keys
 	SPLPlayStatus = 0
@@ -1947,7 +1947,7 @@ class AppModule(appModuleHandler.AppModule):
 	# These are scattered throughout the screen, so one can use foreground.getChild(index) to fetch them (getChild tip from Jamie Teh (NV Access)).
 	# Because 5.x (an perhaps future releases) uses different screen layout, look up the needed constant from the table below (row = info needed, column = version).
 	# As of 18.05, the below table is based on Studio 5.10.
-	statusObjs={
+	statusObjs = {
 		SPLPlayStatus: 6, # Play status, mic, etc.
 		SPLSystemStatus: -2, # The second status bar containing system status such as up time.
 		SPLScheduledToPlay: 19, # In case the user selects one or more tracks in a given hour.
@@ -1979,7 +1979,7 @@ class AppModule(appModuleHandler.AppModule):
 		return self._cachedStatusObjs[infoIndex]
 
 	# Status flags for Studio 5.20 API.
-	_statusBarMessages=(
+	_statusBarMessages = (
 		("Play status: Stopped","Play status: Playing"),
 		("Automation Off","Automation On"),
 		("Microphone Off","Microphone On"),
@@ -2058,7 +2058,7 @@ class AppModule(appModuleHandler.AppModule):
 		finally:
 			self.finish()
 	# Translators: Input help mode message for a command in Station Playlist Studio.
-	script_sayNextTrackTitle.__doc__=_("Announces title of the next track if any")
+	script_sayNextTrackTitle.__doc__ = _("Announces title of the next track if any")
 
 	def script_sayCurrentTrackTitle(self, gesture):
 		if not splbase.studioIsRunning():
@@ -2080,7 +2080,7 @@ class AppModule(appModuleHandler.AppModule):
 		finally:
 			self.finish()
 	# Translators: Input help mode message for a command in Station Playlist Studio.
-	script_sayCurrentTrackTitle.__doc__=_("Announces title of the currently playing track")
+	script_sayCurrentTrackTitle.__doc__ = _("Announces title of the currently playing track")
 
 	def script_sayTemperature(self, gesture):
 		if not splbase.studioIsRunning():
@@ -2096,7 +2096,7 @@ class AppModule(appModuleHandler.AppModule):
 		finally:
 			self.finish()
 	# Translators: Input help mode message for a command in Station Playlist Studio.
-	script_sayTemperature.__doc__=_("Announces temperature and weather information")
+	script_sayTemperature.__doc__ = _("Announces temperature and weather information")
 
 	def script_sayUpTime(self, gesture):
 		obj = self.status(self.SPLSystemStatus).firstChild
@@ -2153,7 +2153,7 @@ class AppModule(appModuleHandler.AppModule):
 				# Translators: Presented when track time analysis is turned off.
 				ui.message(_("Playlist analysis deactivated"))
 	# Translators: Input help mode message for a command in Station Playlist Studio.
-	script_markTrackForAnalysis.__doc__=_("Marks focused track as start marker for various playlist analysis commands")
+	script_markTrackForAnalysis.__doc__ = _("Marks focused track as start marker for various playlist analysis commands")
 
 	def script_trackTimeAnalysis(self, gesture):
 		self.finish()
@@ -2178,7 +2178,7 @@ class AppModule(appModuleHandler.AppModule):
 				# Translators: Presented when time analysis is done for a number of tracks (example output: Tracks: 3, totaling 5:00).
 				ui.message(_("Tracks: {numberOfSelectedTracks}, totaling {totalTime}").format(numberOfSelectedTracks = analysisRange, totalTime = self._ms2time(totalLength*1000)))
 	# Translators: Input help mode message for a command in Station Playlist Studio.
-	script_trackTimeAnalysis.__doc__=_("Announces total length of tracks between analysis start marker and the current track")
+	script_trackTimeAnalysis.__doc__ = _("Announces total length of tracks between analysis start marker and the current track")
 
 	def script_takePlaylistSnapshots(self, gesture):
 		if not splbase.studioIsRunning():
@@ -2212,7 +2212,7 @@ class AppModule(appModuleHandler.AppModule):
 		self.playlistSnapshotOutput(self.playlistSnapshots(start, end), scriptCount)
 		self.finish()
 	# Translators: Input help mode message for a command in Station Playlist Studio.
-	script_takePlaylistSnapshots.__doc__=_("Presents playlist snapshot information such as number of tracks and top artists")
+	script_takePlaylistSnapshots.__doc__ = _("Presents playlist snapshot information such as number of tracks and top artists")
 
 	def script_playlistTranscripts(self, gesture):
 		if not splbase.studioIsRunning():
@@ -2323,7 +2323,7 @@ class AppModule(appModuleHandler.AppModule):
 		else: 
 			os.startfile("https://github.com/josephsl/stationplaylist/wiki/SPLAddonGuide")
 
-	__SPLAssistantGestures={
+	__SPLAssistantGestures = {
 		"kb:p":"sayPlayStatus",
 		"kb:a":"sayAutomationStatus",
 		"kb:m":"sayMicStatus",
@@ -2356,7 +2356,7 @@ class AppModule(appModuleHandler.AppModule):
 		"kb:shift+f1":"openOnlineDoc",
 	}
 
-	__SPLAssistantJFWGestures={
+	__SPLAssistantJFWGestures = {
 		"kb:p":"sayPlayStatus",
 		"kb:a":"sayAutomationStatus",
 		"kb:m":"sayMicStatus",
@@ -2390,7 +2390,7 @@ class AppModule(appModuleHandler.AppModule):
 		"kb:shift+f1":"openOnlineDoc",
 	}
 
-	__SPLAssistantWEGestures={
+	__SPLAssistantWEGestures = {
 		"kb:p":"sayPlayStatus",
 		"kb:a":"sayAutomationStatus",
 		"kb:m":"sayMicStatus",
@@ -2426,7 +2426,7 @@ class AppModule(appModuleHandler.AppModule):
 		"kb:shift+f1":"openOnlineDoc",
 	}
 
-	__gestures={
+	__gestures = {
 		"kb:control+alt+t":"sayRemainingTime",
 		"ts(SPL):2finger_flickDown":"sayRemainingTime",
 		"kb:alt+shift+t":"sayElapsedTime",

--- a/addon/appModules/splstudio/splconfig.py
+++ b/addon/appModules/splstudio/splconfig.py
@@ -108,7 +108,7 @@ WelcomeDialog = boolean(default=true)
 confspec.newlines = "\r\n"
 SPLConfig = None
 # The following settings can be changed in profiles:
-_mutatableSettings=("IntroOutroAlarms", "MicrophoneAlarm", "MetadataStreaming", "ColumnAnnouncement")
+_mutatableSettings = ("IntroOutroAlarms", "MicrophoneAlarm", "MetadataStreaming", "ColumnAnnouncement")
 # 7.0: Profile-specific confspec (might be removed once a more optimal way to validate sections is found).
 # Dictionary comprehension is better here.
 confspecprofiles = {sect:key for sect, key in confspec.items() if sect in _mutatableSettings}
@@ -322,7 +322,7 @@ class ConfigHub(ChainMap):
 		fields = _SPLDefaults["ColumnAnnouncement"]["ColumnOrder"]
 		invalidFields = 0
 		for field in fields:
-			if field not in columnOrder: invalidFields+=1
+			if field not in columnOrder: invalidFields += 1
 		if invalidFields or len(columnOrder) != 17:
 			if profileName in _configLoadStatus and _configLoadStatus[profileName] == "partialReset":
 				_configLoadStatus[profileName] = "partialAndColumnOrderReset"
@@ -696,7 +696,7 @@ def runConfigErrorDialog(errorText, errorType):
 	wx.CallAfter(gui.messageBox, errorText, errorType, wx.OK|wx.ICON_ERROR)
 
 # In case one or more profiles had config issues, look up the error message from the following map.
-_configErrors ={
+_configErrors = {
 	"fileReset":"Settings reset to defaults due to configuration file coruption",
 	"completeReset":"All settings reset to defaults",
 	"partialReset":"Some settings reset to defaults",
@@ -1149,7 +1149,7 @@ class AudioDuckingReminder(wx.Dialog):
 		mainSizer.Add(label,border=20,flag=wx.LEFT|wx.RIGHT|wx.TOP)
 
 		# Translators: A checkbox to turn off audio ducking reminder message.
-		self.audioDuckingReminder=wx.CheckBox(self,wx.ID_ANY,label=_("Do not show this message again"))
+		self.audioDuckingReminder = wx.CheckBox(self,wx.ID_ANY,label=_("Do not show this message again"))
 		self.audioDuckingReminder.SetValue(not SPLConfig["Startup"]["AudioDuckingReminder"])
 		mainSizer.Add(self.audioDuckingReminder, border=10,flag=wx.TOP)
 
@@ -1170,7 +1170,7 @@ class AudioDuckingReminder(wx.Dialog):
 class WelcomeDialog(wx.Dialog):
 
 	# Translators: A message giving basic information about the add-on.
-	welcomeMessage=_("""Welcome to StationPlaylist Studio add-on for NVDA,
+	welcomeMessage = _("""Welcome to StationPlaylist Studio add-on for NVDA,
 your companion to broadcasting with SPL Studio using NVDA screen reader.
 
 Highlights of StationPlaylist Studio add-on include:
@@ -1199,7 +1199,7 @@ Thank you.""")
 		mainSizer.Add(label,border=20,flag=wx.LEFT|wx.RIGHT|wx.TOP)
 
 		# Translators: A checkbox to show welcome dialog.
-		self.showWelcomeDialog=wx.CheckBox(self,wx.ID_ANY,label=_("Show welcome dialog when I start Studio"))
+		self.showWelcomeDialog = wx.CheckBox(self,wx.ID_ANY,label=_("Show welcome dialog when I start Studio"))
 		self.showWelcomeDialog.SetValue(SPLConfig["Startup"]["WelcomeDialog"])
 		mainSizer.Add(self.showWelcomeDialog, border=10,flag=wx.TOP)
 
@@ -1243,7 +1243,7 @@ def message(category, value):
 	verbosityLevels = ("beginner", "advanced")
 	ui.message(messagePool[category][value][verbosityLevels.index(SPLConfig["General"]["MessageVerbosity"])])
 
-messagePool={
+messagePool = {
 	"BeepAnnounce":
 		{True:
 			# Translators: Reported when status announcement is set to beeps in SPL Studio.

--- a/addon/appModules/splstudio/splconfui.py
+++ b/addon/appModules/splstudio/splconfui.py
@@ -397,11 +397,11 @@ class TriggersDialog(wx.Dialog):
 		triggersHelper = gui.guiHelper.BoxSizerHelper(self, orientation=wx.VERTICAL)
 
 		# Translators: The label of a checkbox to toggle if selected profile is an instant switch profile.
-		self.instantSwitchCheckbox=triggersHelper.addItem(wx.CheckBox(self, label=_("This is an &instant switch profile")))
+		self.instantSwitchCheckbox = triggersHelper.addItem(wx.CheckBox(self, label=_("This is an &instant switch profile")))
 		self.instantSwitchCheckbox.SetValue(parent.switchProfile == parent.profiles.GetStringSelection().split(" <")[0])
 
 		# Translators: The label of a checkbox to toggle if selected profile is a time-based profile.
-		self.timeSwitchCheckbox=triggersHelper.addItem(wx.CheckBox(self, label=_("This is a &time-based switch profile")))
+		self.timeSwitchCheckbox = triggersHelper.addItem(wx.CheckBox(self, label=_("This is a &time-based switch profile")))
 		self.timeSwitchCheckbox.SetValue(profile in self.Parent._profileTriggersConfig)
 		self.timeSwitchCheckbox.Bind(wx.EVT_CHECKBOX, self.onTimeSwitch)
 
@@ -409,7 +409,7 @@ class TriggersDialog(wx.Dialog):
 		self.triggerDays = []
 		import calendar
 		for day in six.moves.range(len(calendar.day_name)):
-			triggerDay=wx.CheckBox(self, wx.ID_ANY,label=calendar.day_name[day])
+			triggerDay = wx.CheckBox(self, wx.ID_ANY,label=calendar.day_name[day])
 			triggerDay.SetValue((64 >> day & self.Parent._profileTriggersConfig[profile][0]) if profile in self.Parent._profileTriggersConfig else 0)
 			if not self.timeSwitchCheckbox.IsChecked(): triggerDay.Disable()
 			self.triggerDays.append(triggerDay)
@@ -466,7 +466,7 @@ class TriggersDialog(wx.Dialog):
 		if self.timeSwitchCheckbox.Value:
 			bit = 0
 			for day in self.triggerDays:
-				if day.Value: bit+=64 >> self.triggerDays.index(day)
+				if day.Value: bit += 64 >> self.triggerDays.index(day)
 			if bit:
 				hour, min = self.hourEntry.GetValue(), self.minEntry.GetValue()
 				duration = self.durationEntry.GetValue()
@@ -523,19 +523,19 @@ class GeneralSettingsPanel(gui.SettingsPanel):
 		self.beepAnnounceCheckbox.SetValue(splconfig.SPLConfig["General"]["BeepAnnounce"])
 
 		# Translators: One of the message verbosity levels.
-		self.verbosityLevels=[("beginner",_("beginner")),
+		self.verbosityLevels = [("beginner",_("beginner")),
 		# Translators: One of the message verbosity levels.
 		("advanced",_("advanced"))]
 		# Translators: The label for a setting in SPL add-on dialog to set message verbosity.
 		self.verbosityList = generalSettingsHelper.addLabeledControl(_("Message &verbosity:"), wx.Choice, choices=[x[1] for x in self.verbosityLevels])
-		currentVerbosity=splconfig.SPLConfig["General"]["MessageVerbosity"]
-		selection = next((x for x,y in enumerate(self.verbosityLevels) if y[0]==currentVerbosity))
+		currentVerbosity = splconfig.SPLConfig["General"]["MessageVerbosity"]
+		selection = next((x for x,y in enumerate(self.verbosityLevels) if y[0] == currentVerbosity))
 		try:
 			self.verbosityList.SetSelection(selection)
 		except:
 			pass
 
-		self.brailleTimerValues=[("off",_("Off")),
+		self.brailleTimerValues = [("off",_("Off")),
 		# Translators: One of the braille timer settings.
 		("outro",_("Track ending")),
 		# Translators: One of the braille timer settings.
@@ -544,14 +544,14 @@ class GeneralSettingsPanel(gui.SettingsPanel):
 		("both",_("Track intro and ending"))]
 		# Translators: The label for a setting in SPL add-on dialog to control braille timer.
 		self.brailleTimerList = generalSettingsHelper.addLabeledControl(_("&Braille timer:"), wx.Choice, choices=[x[1] for x in self.brailleTimerValues])
-		brailleTimerCurValue=splconfig.SPLConfig["General"]["BrailleTimer"]
-		selection = next((x for x,y in enumerate(self.brailleTimerValues) if y[0]==brailleTimerCurValue))
+		brailleTimerCurValue = splconfig.SPLConfig["General"]["BrailleTimer"]
+		selection = next((x for x,y in enumerate(self.brailleTimerValues) if y[0] == brailleTimerCurValue))
 		try:
 			self.brailleTimerList.SetSelection(selection)
 		except:
 			pass
 
-		self.libScanValues=[("off",_("Off")),
+		self.libScanValues = [("off",_("Off")),
 		# Translators: One of the library scan announcement settings.
 		("ending",_("Start and end only")),
 		# Translators: One of the library scan announcement settings.
@@ -560,8 +560,8 @@ class GeneralSettingsPanel(gui.SettingsPanel):
 		("numbers",_("Scan count"))]
 		# Translators: The label for a setting in SPL add-on dialog to control library scan announcement.
 		self.libScanList = generalSettingsHelper.addLabeledControl(_("&Library scan announcement:"), wx.Choice, choices=[x[1] for x in self.libScanValues])
-		libScanCurValue=splconfig.SPLConfig["General"]["LibraryScanAnnounce"]
-		selection = next((x for x,y in enumerate(self.libScanValues) if y[0]==libScanCurValue))
+		libScanCurValue = splconfig.SPLConfig["General"]["LibraryScanAnnounce"]
+		selection = next((x for x,y in enumerate(self.libScanValues) if y[0] == libScanCurValue))
 		try:
 			self.libScanList.SetSelection(selection)
 		except:
@@ -586,7 +586,7 @@ class GeneralSettingsPanel(gui.SettingsPanel):
 		self.categorySoundsCheckbox = generalSettingsHelper.addItem(wx.CheckBox(self, label=_("&Beep for different track categories")))
 		self.categorySoundsCheckbox.SetValue(splconfig.SPLConfig["General"]["CategorySounds"])
 
-		self.trackCommentValues=[("off",_("Off")),
+		self.trackCommentValues = [("off",_("Off")),
 		# Translators: One of the track comment notification settings.
 		("message",_("Message")),
 		# Translators: One of the track comment notification settings.
@@ -595,8 +595,8 @@ class GeneralSettingsPanel(gui.SettingsPanel):
 		("both",_("Both"))]
 		# Translators: the label for a setting in SPL add-on settings to set how track comments are announced.
 		self.trackCommentList = generalSettingsHelper.addLabeledControl(_("&Track comment announcement:"), wx.Choice, choices=[x[1] for x in self.trackCommentValues])
-		trackCommentCurValue=splconfig.SPLConfig["General"]["TrackCommentAnnounce"]
-		selection = next((x for x,y in enumerate(self.trackCommentValues) if y[0]==trackCommentCurValue))
+		trackCommentCurValue = splconfig.SPLConfig["General"]["TrackCommentAnnounce"]
+		selection = next((x for x,y in enumerate(self.trackCommentValues) if y[0] == trackCommentCurValue))
 		try:
 			self.trackCommentList.SetSelection(selection)
 		except:
@@ -671,13 +671,13 @@ class AlarmsCenter(wx.Dialog):
 		if level in (0, 1):
 			timeVal = parent.endOfTrackTime if level == 0 else splconfig.SPLConfig["IntroOutroAlarms"]["EndOfTrackTime"]
 			self.outroAlarmEntry = alarmsCenterHelper.addLabeledControl(_("&End of track alarm in seconds"), gui.nvdaControls.SelectOnFocusSpinCtrl, min=1, max=59, initial=timeVal)
-			self.outroToggleCheckBox=alarmsCenterHelper.addItem(wx.CheckBox(self, label=_("&Notify when end of track is approaching")))
+			self.outroToggleCheckBox = alarmsCenterHelper.addItem(wx.CheckBox(self, label=_("&Notify when end of track is approaching")))
 			self.outroToggleCheckBox.SetValue(parent.sayEndOfTrack if level == 0 else splconfig.SPLConfig["IntroOutroAlarms"]["SayEndOfTrack"])
 
 		if level in (0, 2):
 			rampVal = parent.songRampTime if level == 0 else splconfig.SPLConfig["IntroOutroAlarms"]["SongRampTime"]
 			self.introAlarmEntry = alarmsCenterHelper.addLabeledControl(_("&Track intro alarm in seconds"), gui.nvdaControls.SelectOnFocusSpinCtrl, min=1, max=9, initial=rampVal)
-			self.introToggleCheckBox=alarmsCenterHelper.addItem(wx.CheckBox(self, label=_("&Notify when end of introduction is approaching")))
+			self.introToggleCheckBox = alarmsCenterHelper.addItem(wx.CheckBox(self, label=_("&Notify when end of introduction is approaching")))
 			self.introToggleCheckBox.SetValue(parent.saySongRamp if level == 0 else splconfig.SPLConfig["IntroOutroAlarms"]["SaySongRamp"])
 
 		if level in (0, 3):
@@ -752,26 +752,26 @@ class AlarmsPanel(gui.SettingsPanel):
 		# #77 (18.09-LTS): record temporary settings.
 		self._curProfileSettings = {}
 		self.outroAlarmEntry = alarmsCenterHelper.addLabeledControl(_("&End of track alarm in seconds"), gui.nvdaControls.SelectOnFocusSpinCtrl, min=1, max=59, initial=splconfig._SPLDefaults["IntroOutroAlarms"]["EndOfTrackTime"])
-		self.outroToggleCheckBox=alarmsCenterHelper.addItem(wx.CheckBox(self, label=_("&Notify when end of track is approaching")))
+		self.outroToggleCheckBox = alarmsCenterHelper.addItem(wx.CheckBox(self, label=_("&Notify when end of track is approaching")))
 		self.outroToggleCheckBox.SetValue(splconfig._SPLDefaults["IntroOutroAlarms"]["SayEndOfTrack"])
 
 		self.introAlarmEntry = alarmsCenterHelper.addLabeledControl(_("&Track intro alarm in seconds"), gui.nvdaControls.SelectOnFocusSpinCtrl, min=1, max=9, initial=splconfig._SPLDefaults["IntroOutroAlarms"]["SongRampTime"])
-		self.introToggleCheckBox=alarmsCenterHelper.addItem(wx.CheckBox(self, label=_("&Notify when end of introduction is approaching")))
+		self.introToggleCheckBox = alarmsCenterHelper.addItem(wx.CheckBox(self, label=_("&Notify when end of introduction is approaching")))
 		self.introToggleCheckBox.SetValue(splconfig._SPLDefaults["IntroOutroAlarms"]["SaySongRamp"])
 
 		self.micAlarmEntry = alarmsCenterHelper.addLabeledControl(_("&Microphone alarm in seconds (0 disables the alarm)"), gui.nvdaControls.SelectOnFocusSpinCtrl, min=0, max=7200, initial=splconfig._SPLDefaults["MicrophoneAlarm"]["MicAlarm"])
 		self.micIntervalEntry = alarmsCenterHelper.addLabeledControl(_("Microphone alarm &interval in seconds"), gui.nvdaControls.SelectOnFocusSpinCtrl, min=0, max=60, initial=splconfig._SPLDefaults["MicrophoneAlarm"]["MicAlarmInterval"])
 
 		# Translators: One of the alarm notification options.
-		self.alarmAnnounceValues=[("beep",_("beep")),
+		self.alarmAnnounceValues = [("beep",_("beep")),
 		# Translators: One of the alarm notification options.
 		("message",_("message")),
 		# Translators: One of the alarm notification options.
 		("both",_("both beep and message"))]
 		# Translators: The label for a setting in SPL add-on dialog to control alarm announcement type.
 		self.alarmAnnounceList = alarmsCenterHelper.addLabeledControl(_("&Alarm notification:"), wx.Choice, choices=[x[1] for x in self.alarmAnnounceValues])
-		alarmAnnounceCurValue=splconfig.SPLConfig["General"]["AlarmAnnounce"]
-		selection = next((x for x,y in enumerate(self.alarmAnnounceValues) if y[0]==alarmAnnounceCurValue))
+		alarmAnnounceCurValue = splconfig.SPLConfig["General"]["AlarmAnnounce"]
+		selection = next((x for x,y in enumerate(self.alarmAnnounceValues) if y[0] == alarmAnnounceCurValue))
 		try:
 			self.alarmAnnounceList.SetSelection(selection)
 		except:
@@ -841,28 +841,28 @@ class PlaylistSnapshotsPanel(gui.SettingsPanel):
 		playlistSnapshotsHelper.addItem(wx.StaticText(self, label=labelText))
 
 		# Translators: the label for a setting in SPL add-on settings to include shortest and longest track duration in playlist snapshots window.
-		self.playlistDurationMinMaxCheckbox=playlistSnapshotsHelper.addItem(wx.CheckBox(self, label=_("Shortest and longest tracks")))
+		self.playlistDurationMinMaxCheckbox = playlistSnapshotsHelper.addItem(wx.CheckBox(self, label=_("Shortest and longest tracks")))
 		self.playlistDurationMinMaxCheckbox.SetValue(splconfig.SPLConfig["PlaylistSnapshots"]["DurationMinMax"])
 		# Translators: the label for a setting in SPL add-on settings to include average track duration in playlist snapshots window.
-		self.playlistDurationAverageCheckbox=playlistSnapshotsHelper.addItem(wx.CheckBox(self, label=_("Average track duration")))
+		self.playlistDurationAverageCheckbox = playlistSnapshotsHelper.addItem(wx.CheckBox(self, label=_("Average track duration")))
 		self.playlistDurationAverageCheckbox.SetValue(splconfig.SPLConfig["PlaylistSnapshots"]["DurationAverage"])
 		# Translators: the label for a setting in SPL add-on settings to include track artist count in playlist snapshots window.
-		self.playlistArtistCountCheckbox=playlistSnapshotsHelper.addItem(wx.CheckBox(self, label=_("Artist count")))
+		self.playlistArtistCountCheckbox = playlistSnapshotsHelper.addItem(wx.CheckBox(self, label=_("Artist count")))
 		self.playlistArtistCountCheckbox.SetValue(splconfig.SPLConfig["PlaylistSnapshots"]["ArtistCount"])
 		# Translators: the label for a setting in SPL add-on settings to set top artist count limit in playlist snapshots window.
-		self.playlistArtistCountLimit=playlistSnapshotsHelper.addLabeledControl(_("Top artist count (0 displays all artists)"), gui.nvdaControls.SelectOnFocusSpinCtrl, min=0, max=10, initial=splconfig.SPLConfig["PlaylistSnapshots"]["ArtistCountLimit"])
+		self.playlistArtistCountLimit = playlistSnapshotsHelper.addLabeledControl(_("Top artist count (0 displays all artists)"), gui.nvdaControls.SelectOnFocusSpinCtrl, min=0, max=10, initial=splconfig.SPLConfig["PlaylistSnapshots"]["ArtistCountLimit"])
 		# Translators: the label for a setting in SPL add-on settings to include track category count in playlist snapshots window.
-		self.playlistCategoryCountCheckbox=playlistSnapshotsHelper.addItem(wx.CheckBox(self, label=_("Category count")))
+		self.playlistCategoryCountCheckbox = playlistSnapshotsHelper.addItem(wx.CheckBox(self, label=_("Category count")))
 		self.playlistCategoryCountCheckbox.SetValue(splconfig.SPLConfig["PlaylistSnapshots"]["CategoryCount"])
 		# Translators: the label for a setting in SPL add-on settings to set top track category count limit in playlist snapshots window.
-		self.playlistCategoryCountLimit=playlistSnapshotsHelper.addLabeledControl(_("Top category count (0 displays all categories)"), gui.nvdaControls.SelectOnFocusSpinCtrl, min=0, max=10, initial=splconfig.SPLConfig["PlaylistSnapshots"]["CategoryCountLimit"])
+		self.playlistCategoryCountLimit = playlistSnapshotsHelper.addLabeledControl(_("Top category count (0 displays all categories)"), gui.nvdaControls.SelectOnFocusSpinCtrl, min=0, max=10, initial=splconfig.SPLConfig["PlaylistSnapshots"]["CategoryCountLimit"])
 		# Translators: the label for a setting in SPL add-on settings to include track genre count in playlist snapshots window.
-		self.playlistGenreCountCheckbox=playlistSnapshotsHelper.addItem(wx.CheckBox(self, label=_("Genre count")))
+		self.playlistGenreCountCheckbox = playlistSnapshotsHelper.addItem(wx.CheckBox(self, label=_("Genre count")))
 		self.playlistGenreCountCheckbox.SetValue(splconfig.SPLConfig["PlaylistSnapshots"]["GenreCount"])
 		# Translators: the label for a setting in SPL add-on settings to set top track genre count limit in playlist snapshots window.
-		self.playlistGenreCountLimit=playlistSnapshotsHelper.addLabeledControl(_("Top genre count (0 displays all genres)"), gui.nvdaControls.SelectOnFocusSpinCtrl, min=0, max=10, initial=splconfig.SPLConfig["PlaylistSnapshots"]["GenreCountLimit"])
+		self.playlistGenreCountLimit = playlistSnapshotsHelper.addLabeledControl(_("Top genre count (0 displays all genres)"), gui.nvdaControls.SelectOnFocusSpinCtrl, min=0, max=10, initial=splconfig.SPLConfig["PlaylistSnapshots"]["GenreCountLimit"])
 		# Translators: the label for a setting in SPL add-on settings to show playlist snaphsots window when the snapshots command is pressed once.
-		self.resultsWindowOnFirstPressCheckbox=playlistSnapshotsHelper.addItem(wx.CheckBox(self, label=_("&Show results window when playlist snapshots command is performed once")))
+		self.resultsWindowOnFirstPressCheckbox = playlistSnapshotsHelper.addItem(wx.CheckBox(self, label=_("&Show results window when playlist snapshots command is performed once")))
 		self.resultsWindowOnFirstPressCheckbox.SetValue(splconfig.SPLConfig["PlaylistSnapshots"]["ShowResultsWindowOnFirstPress"])
 
 	def onSave(self):
@@ -910,8 +910,8 @@ class MetadataStreamingDialog(wx.Dialog):
 		metadataSizerHelper = gui.guiHelper.BoxSizerHelper(self, orientation=wx.VERTICAL)
 		splactions.SPLActionAppTerminating.register(self.onAppTerminate)
 
-		if configDialogActive: labelText=_("Select the URL for metadata streaming upon request.")
-		else: labelText=_("Check to enable metadata streaming, uncheck to disable.")
+		if configDialogActive: labelText = _("Select the URL for metadata streaming upon request.")
+		else: labelText = _("Check to enable metadata streaming, uncheck to disable.")
 		metadataSizerHelper.addItem(wx.StaticText(self, label=labelText))
 
 		# WX's native CheckListBox isn't user friendly.
@@ -976,15 +976,15 @@ class MetadataStreamingPanel(gui.SettingsPanel):
 	def makeSettings(self, settingsSizer):
 		metadataSizerHelper = gui.guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
 
-		self.metadataValues=[("off",_("Off")),
+		self.metadataValues = [("off",_("Off")),
 		# Translators: One of the metadata notification settings.
 		("startup",_("When Studio starts")),
 		# Translators: One of the metadata notification settings.
 		("instant",_("When instant switch profile is active"))]
 		# Translators: the label for a setting in SPL add-on settings to be notified that metadata streaming is enabled.
 		self.metadataList = metadataSizerHelper.addLabeledControl(_("&Metadata streaming notification and connection"), wx.Choice, choices=[x[1] for x in self.metadataValues])
-		metadataCurValue=splconfig.SPLConfig["General"]["MetadataReminder"]
-		selection = next((x for x,y in enumerate(self.metadataValues) if y[0]==metadataCurValue))
+		metadataCurValue = splconfig.SPLConfig["General"]["MetadataReminder"]
+		selection = next((x for x,y in enumerate(self.metadataValues) if y[0] == metadataCurValue))
 		try:
 			self.metadataList.SetSelection(selection)
 		except:
@@ -1088,7 +1088,7 @@ class ColumnAnnouncementsPanel(ColumnAnnouncementsBasePanel):
 		self._curProfileSettings = {}
 
 		# Translators: the label for a setting in SPL add-on settings to toggle custom column announcement.
-		self.columnOrderCheckbox=colAnnouncementsHelper.addItem(wx.CheckBox(self,wx.ID_ANY,label=_("Announce columns in the &order shown on screen")))
+		self.columnOrderCheckbox = colAnnouncementsHelper.addItem(wx.CheckBox(self,wx.ID_ANY,label=_("Announce columns in the &order shown on screen")))
 		self.columnOrderCheckbox.SetValue(splconfig._SPLDefaults["ColumnAnnouncement"]["UseScreenColumnOrder"])
 
 		# Translators: Help text to select columns to be announced.
@@ -1374,30 +1374,30 @@ class SayStatusPanel(gui.SettingsPanel):
 		sayStatusHelper = gui.guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
 
 		# Translators: the label for a setting in SPL add-on settings to announce scheduled time.
-		self.scheduledForCheckbox=sayStatusHelper.addItem(wx.CheckBox(self, label=_("Announce &scheduled time for the selected track")))
+		self.scheduledForCheckbox = sayStatusHelper.addItem(wx.CheckBox(self, label=_("Announce &scheduled time for the selected track")))
 		self.scheduledForCheckbox.SetValue(splconfig.SPLConfig["SayStatus"]["SayScheduledFor"])
 		# Translators: the label for a setting in SPL add-on settings to announce listener count.
-		self.listenerCountCheckbox=sayStatusHelper.addItem(wx.CheckBox(self, label=_("Announce &listener count")))
+		self.listenerCountCheckbox = sayStatusHelper.addItem(wx.CheckBox(self, label=_("Announce &listener count")))
 		self.listenerCountCheckbox.SetValue(splconfig.SPLConfig["SayStatus"]["SayListenerCount"])
 		# Translators: the label for a setting in SPL add-on settings to announce currently playing cart.
-		self.cartNameCheckbox=sayStatusHelper.addItem(wx.CheckBox(self, label=_("&Announce name of the currently playing cart")))
+		self.cartNameCheckbox = sayStatusHelper.addItem(wx.CheckBox(self, label=_("&Announce name of the currently playing cart")))
 		self.cartNameCheckbox.SetValue(splconfig.SPLConfig["SayStatus"]["SayPlayingCartName"])
 		# Translators: the label for a setting in SPL add-on settings to announce currently playing track name.
 		labelText = _("&Track name announcement:")
 		# Translators: One of the track name announcement options.
-		self.trackAnnouncements=[("auto",_("automatic")),
+		self.trackAnnouncements = [("auto",_("automatic")),
 		# Translators: One of the track name announcement options.
 		("background",_("while using other programs")),
 		# Translators: One of the track name announcement options.
 		("off",_("off"))]
-		self.trackAnnouncementList=sayStatusHelper.addLabeledControl(labelText, wx.Choice, choices=[x[1] for x in self.trackAnnouncements])
-		selection = next((x for x,y in enumerate(self.trackAnnouncements) if y[0]==splconfig.SPLConfig["SayStatus"]["SayPlayingTrackName"]))
+		self.trackAnnouncementList = sayStatusHelper.addLabeledControl(labelText, wx.Choice, choices=[x[1] for x in self.trackAnnouncements])
+		selection = next((x for x,y in enumerate(self.trackAnnouncements) if y[0] == splconfig.SPLConfig["SayStatus"]["SayPlayingTrackName"]))
 		try:
 			self.trackAnnouncementList.SetSelection(selection)
 		except:
 			pass
 		# Translators: the label for a setting in SPL add-on settings to announce player position for the current and next tracks.
-		self.playerPositionCheckbox=sayStatusHelper.addItem(wx.CheckBox(self, label=_("Include track player &position when announcing current and next track information")))
+		self.playerPositionCheckbox = sayStatusHelper.addItem(wx.CheckBox(self, label=_("Include track player &position when announcing current and next track information")))
 		self.playerPositionCheckbox.SetValue(splconfig.SPLConfig["SayStatus"]["SayStudioPlayerPosition"])
 
 	def onSave(self):
@@ -1421,22 +1421,22 @@ class AdvancedOptionsPanel(gui.SettingsPanel):
 		advOptionsHelper = gui.guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
 
 		# Translators: A checkbox to toggle if SPL Controller command can be used to invoke Assistant layer.
-		self.splConPassthroughCheckbox=advOptionsHelper.addItem(wx.CheckBox(self, label=_("Allow SPL C&ontroller command to invoke SPL Assistant layer")))
+		self.splConPassthroughCheckbox = advOptionsHelper.addItem(wx.CheckBox(self, label=_("Allow SPL C&ontroller command to invoke SPL Assistant layer")))
 		self.splConPassthroughCheckbox.SetValue(splconfig.SPLConfig["Advanced"]["SPLConPassthrough"])
 		# Translators: The label for a setting in SPL add-on dialog to set keyboard layout for SPL Assistant.
 		labelText = _("SPL Assistant command &layout:")
-		self.compatibilityLayouts=[("off","NVDA"),
+		self.compatibilityLayouts = [("off","NVDA"),
 		("jfw","JAWS for Windows"),
 		("wineyes","Window-Eyes")]
-		self.compatibilityList=advOptionsHelper.addLabeledControl(labelText, wx.Choice, choices=[x[1] for x in self.compatibilityLayouts])
-		selection = next((x for x,y in enumerate(self.compatibilityLayouts) if y[0]==splconfig.SPLConfig["Advanced"]["CompatibilityLayer"]))
+		self.compatibilityList = advOptionsHelper.addLabeledControl(labelText, wx.Choice, choices=[x[1] for x in self.compatibilityLayouts])
+		selection = next((x for x,y in enumerate(self.compatibilityLayouts) if y[0] == splconfig.SPLConfig["Advanced"]["CompatibilityLayer"]))
 		try:
 			self.compatibilityList.SetSelection(selection)
 		except:
 			pass
 		# 18.09: allow some dev snapshot users to test pilot features.
 		# Translators: A checkbox to enable pilot features (with risks involved).
-		self.pilotBuildCheckbox=advOptionsHelper.addItem(wx.CheckBox(self, label=_("Pilot features: I want to test and provide early &feedback on features under development")))
+		self.pilotBuildCheckbox = advOptionsHelper.addItem(wx.CheckBox(self, label=_("Pilot features: I want to test and provide early &feedback on features under development")))
 		self.pilotBuildCheckbox.SetValue(splconfig.SPLConfig["Advanced"]["PilotFeatures"])
 		if not splconfig.SPLConfig.canEnablePilotFeatures: self.pilotBuildCheckbox.Disable()
 
@@ -1476,13 +1476,13 @@ class ResetDialog(wx.Dialog):
 		resetHelper = gui.guiHelper.BoxSizerHelper(self, orientation=wx.VERTICAL)
 
 		# Translators: the label for resetting profile triggers.
-		self.resetInstantProfileCheckbox=resetHelper.addItem(wx.CheckBox(self,label=_("Reset instant switch profile")))
+		self.resetInstantProfileCheckbox = resetHelper.addItem(wx.CheckBox(self,label=_("Reset instant switch profile")))
 		# Translators: the label for resetting profile triggers.
-		self.resetTimeProfileCheckbox=resetHelper.addItem(wx.CheckBox(self,label=_("Delete time-based profile database")))
+		self.resetTimeProfileCheckbox = resetHelper.addItem(wx.CheckBox(self,label=_("Delete time-based profile database")))
 		# Translators: the label for resetting encoder settings.
-		self.resetEncodersCheckbox=resetHelper.addItem(wx.CheckBox(self,label=_("Remove encoder settings")))
+		self.resetEncodersCheckbox = resetHelper.addItem(wx.CheckBox(self,label=_("Remove encoder settings")))
 		# Translators: the label for resetting track comments.
-		self.resetTrackCommentsCheckbox=resetHelper.addItem(wx.CheckBox(self,label=_("Erase track comments")))
+		self.resetTrackCommentsCheckbox = resetHelper.addItem(wx.CheckBox(self,label=_("Erase track comments")))
 
 		resetHelper.addDialogDismissButtons(self.CreateButtonSizer(wx.OK | wx.CANCEL))
 		self.Bind(wx.EVT_BUTTON, self.onOk, id=wx.ID_OK)
@@ -1500,7 +1500,7 @@ class ResetDialog(wx.Dialog):
 		_("Are you sure you wish to reset SPL add-on settings to defaults?"),
 		# Translators: The title of the warning dialog.
 		_("Warning"),wx.YES_NO|wx.NO_DEFAULT|wx.ICON_WARNING,self
-		)!=wx.YES:
+		) != wx.YES:
 			parent.Enable()
 			self.Destroy()
 			return
@@ -1576,7 +1576,7 @@ _configDialogOpened = False
 class SPLConfigDialog(gui.MultiCategorySettingsDialog):
 	# Translators: This is the label for the StationPlaylist Studio configuration dialog.
 	title = _("Studio Add-on Settings")
-	categoryClasses=[
+	categoryClasses = [
 		BroadcastProfilesPanel,
 		GeneralSettingsPanel,
 		AlarmsPanel,

--- a/addon/appModules/tracktool.py
+++ b/addon/appModules/tracktool.py
@@ -72,7 +72,7 @@ class TrackToolItem(SPLTrackItem):
 	def exploreColumns(self):
 		return splconfig.SPLConfig["General"]["ExploreColumnsTT"]
 
-	__gestures={
+	__gestures = {
 		"kb:control+alt+downArrow": None,
 		"kb:control+alt+upArrow": None,
 	}

--- a/addon/globalPlugins/splUtils/__init__.py
+++ b/addon/globalPlugins/splUtils/__init__.py
@@ -48,7 +48,7 @@ SPLCurTrackPlaybackTime = 105
 
 # Help message for SPL Controller
 # Translators: the dialog text for SPL Controller help.
-SPLConHelp=_("""
+SPLConHelp = _("""
 After entering SPL Controller, press:
 A: Turn automation on.
 Shift+A: Turn automation off.
@@ -112,7 +112,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		# 17.01: SetForegroundWindow function is better, as there's no need to traverse top-level windows and allows users to "switch" to SPL window if the window is minimized.
 		else: user32.SetForegroundWindow(user32.FindWindowW(u"TStudioForm", None))
 	# Translators: Input help mode message for a command to switch to Station Playlist Studio from any program.
-	script_focusToSPLWindow.__doc__=_("Moves to SPL Studio window from other programs.")
+	script_focusToSPLWindow.__doc__ = _("Moves to SPL Studio window from other programs.")
 
 	# The SPL Controller:
 	# This layer set allows the user to control various aspects of SPL Studio from anywhere.
@@ -143,7 +143,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			# Exclude number row if Studio Standard is running.
 			cartKeys = self.fnCartKeys
 			if not getNVDAObjectFromEvent(user32.FindWindowW(u"TStudioForm", None), OBJID_CLIENT, 0).name.startswith("StationPlaylist Studio Standard"):
-				cartKeys+=self.numCartKeys
+				cartKeys += self.numCartKeys
 			for cart in cartKeys:
 				self.bindGesture("kb:%s"%cart, "cartsWithoutBorders")
 				self.bindGesture("kb:shift+%s"%cart, "cartsWithoutBorders")
@@ -157,7 +157,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			self.script_error(gesture)
 			self.finish()
 	# Translators: Input help mode message for a layer command in Station Playlist Studio.
-	script_SPLControllerPrefix.__doc__=_("SPl Controller layer command. See add-on guide for available commands.")
+	script_SPLControllerPrefix.__doc__ = _("SPl Controller layer command. See add-on guide for available commands.")
 
 	# The layer commands themselves. Calls user32.SendMessage method for each script.
 
@@ -310,7 +310,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		wx.CallAfter(gui.messageBox, SPLConHelp, _("SPL Controller help"))
 		self.finish()
 
-	__SPLControllerGestures={
+	__SPLControllerGestures = {
 		"kb:p":"play",
 		"kb:a":"automateOn",
 		"kb:shift+a":"automateOff",
@@ -332,7 +332,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		"kb:h":"conHelp"
 	}
 
-	__gestures={}
+	__gestures = {}
 
 	# Support for Encoders
 	# Each encoder is an overlay class, thus makes it easier to add encoders in the future by implementing overlay objects.

--- a/addon/globalPlugins/splUtils/encoders.py
+++ b/addon/globalPlugins/splUtils/encoders.py
@@ -28,8 +28,8 @@ SPLBackgroundMonitor = set()
 SPLNoConnectionTone = set()
 
 # Customized for each encoder type.
-SAMStreamLabels= {} # A dictionary to store custom labels for each stream.
-SPLStreamLabels= {} # Same as above but optimized for SPL encoders (Studio 5.00 and later).
+SAMStreamLabels = {} # A dictionary to store custom labels for each stream.
+SPLStreamLabels = {} # Same as above but optimized for SPL encoders (Studio 5.00 and later).
 SAMMonitorThreads = {}
 SPLMonitorThreads = {}
 encoderMonCount = {"SAM":0, "SPL":0}
@@ -317,7 +317,7 @@ class Encoder(IAccessible):
 			ui.message(_("Do not switch to Studio after connecting"))
 		self._setFlags(self.encoderId, not self.focusToStudio, SPLFocusToStudio, "FocusToStudio")
 	# Translators: Input help mode message in SAM Encoder window.
-	script_toggleFocusToStudio.__doc__=_("Toggles whether NVDA will switch to Studio when connected to a streaming server.")
+	script_toggleFocusToStudio.__doc__ = _("Toggles whether NVDA will switch to Studio when connected to a streaming server.")
 
 	def script_togglePlay(self, gesture):
 		if not self.playAfterConnecting:
@@ -328,10 +328,10 @@ class Encoder(IAccessible):
 			ui.message(_("Do not play first track after connecting"))
 		self._setFlags(self.encoderId, not self.playAfterConnecting, SPLPlayAfterConnecting, "PlayAfterConnecting")
 	# Translators: Input help mode message in SAM Encoder window.
-	script_togglePlay.__doc__=_("Toggles whether Studio will play the first song when connected to a streaming server.")
+	script_togglePlay.__doc__ = _("Toggles whether Studio will play the first song when connected to a streaming server.")
 
 	def script_toggleBackgroundEncoderMonitor(self, gesture):
-		if scriptHandler.getLastScriptRepeatCount()==0:
+		if scriptHandler.getLastScriptRepeatCount() == 0:
 			if not self.backgroundMonitor:
 				encoderMonCount[self.encoderType] += 1 # Multiple encoders.
 				# Translators: Presented when toggling the setting to monitor the selected encoder.
@@ -354,7 +354,7 @@ class Encoder(IAccessible):
 			# Translators: Announced when background encoder monitoring is canceled.
 			ui.message(_("Encoder monitoring canceled"))
 	# Translators: Input help mode message in SAM Encoder window.
-	script_toggleBackgroundEncoderMonitor.__doc__=_("Toggles whether NVDA will monitor the selected encoder in the background.")
+	script_toggleBackgroundEncoderMonitor.__doc__ = _("Toggles whether NVDA will monitor the selected encoder in the background.")
 
 	def script_streamLabeler(self, gesture):
 		curStreamLabel, title = self.getStreamLabel(getTitle=True)
@@ -373,7 +373,7 @@ class Encoder(IAccessible):
 				else: self.setStreamLabel(newStreamLabel)
 		gui.runScriptModalDialog(dlg, callback)
 	# Translators: Input help mode message in SAM Encoder window.
-	script_streamLabeler.__doc__=_("Opens a dialog to label the selected encoder.")
+	script_streamLabeler.__doc__ = _("Opens a dialog to label the selected encoder.")
 
 	def removeStreamConfig(self, pos):
 		# An application of map successor algorithm.
@@ -432,7 +432,7 @@ class Encoder(IAccessible):
 				self.removeStreamConfig(dlg.GetStringSelection())
 		gui.runScriptModalDialog(dlg, callback)
 	# Translators: Input help mode message in SAM Encoder window.
-	script_streamLabelEraser.__doc__=_("Opens a dialog to erase stream labels and settings from an encoder that was deleted.")
+	script_streamLabelEraser.__doc__ = _("Opens a dialog to erase stream labels and settings from an encoder that was deleted.")
 
 	# stream settings.
 	def script_encoderSettings(self, gesture):
@@ -447,20 +447,20 @@ class Encoder(IAccessible):
 			# Translators: Text of the dialog when another alarm dialog is open.
 			wx.CallAfter(gui.messageBox, _("Another encoder settings dialog is open."),translate("Error"),style=wx.OK | wx.ICON_ERROR)
 	# Translators: Input help mode message for a command in Station Playlist Studio.
-	script_encoderSettings.__doc__=_("Shows encoder configuration dialog to configure various encoder settings such as stream label.")
-	script_encoderSettings.category=_("Station Playlist Studio")
+	script_encoderSettings.__doc__ = _("Shows encoder configuration dialog to configure various encoder settings such as stream label.")
+	script_encoderSettings.category = _("Station Playlist Studio")
 
 	# Announce complete time including seconds (slight change from global commands version).
 	def script_encoderDateTime(self, gesture):
 		import winKernel
-		if scriptHandler.getLastScriptRepeatCount()==0:
-			text=winKernel.GetTimeFormat(winKernel.LOCALE_USER_DEFAULT, 0, None, None)
+		if scriptHandler.getLastScriptRepeatCount() == 0:
+			text = winKernel.GetTimeFormat(winKernel.LOCALE_USER_DEFAULT, 0, None, None)
 		else:
-			text=winKernel.GetDateFormat(winKernel.LOCALE_USER_DEFAULT, winKernel.DATE_LONGDATE, None, None)
+			text = winKernel.GetDateFormat(winKernel.LOCALE_USER_DEFAULT, winKernel.DATE_LONGDATE, None, None)
 		ui.message(text)
 	# Translators: Input help mode message for report date and time command.
-	script_encoderDateTime.__doc__=_("If pressed once, reports the current time including seconds. If pressed twice, reports the current date")
-	script_encoderDateTime.category=_("Station Playlist Studio")
+	script_encoderDateTime.__doc__ = _("If pressed once, reports the current time including seconds. If pressed twice, reports the current date")
+	script_encoderDateTime.category = _("Station Playlist Studio")
 
 	# Various column announcement scripts.
 	# This base class implements encoder position and stream labels.
@@ -505,7 +505,7 @@ class Encoder(IAccessible):
 				pass
 		super(Encoder, self).reportFocus()
 
-	__gestures={
+	__gestures = {
 		"kb:f11":"toggleFocusToStudio",
 		"kb:shift+f11":"togglePlay",
 		"kb:control+f11":"toggleBackgroundEncoderMonitor",
@@ -570,7 +570,7 @@ class SAMEncoder(Encoder, sysListView32.ListItem):
 					toneCounter = 0
 			elif messageCache.startswith("Error"):
 				# Announce the description of the error.
-				if connecting: connecting= False
+				if connecting: connecting = False
 				if not error:
 					error = True
 					toneCounter = 0
@@ -595,7 +595,7 @@ class SAMEncoder(Encoder, sysListView32.ListItem):
 				if alreadyEncoding: alreadyEncoding = False
 				if encoding: encoding = False
 				elif "Error" not in self.description and error: error = False
-				toneCounter+=1
+				toneCounter += 1
 				if toneCounter%250 == 0 and self.connectionTone:
 					tones.beep(500, 50)
 			if connecting: continue
@@ -621,7 +621,7 @@ class SAMEncoder(Encoder, sysListView32.ListItem):
 	def _samContextMenu(self, pos):
 		def _samContextMenuActivate(pos):
 			speech.cancelSpeech()
-			focus =api.getFocusObject()
+			focus = api.getFocusObject()
 			focus.children[pos].doAction()
 		import keyboardHandler
 		contextMenu = keyboardHandler.KeyboardInputGesture.fromName("applications")
@@ -686,7 +686,7 @@ class SAMEncoder(Encoder, sysListView32.ListItem):
 		streamLabels["SAMEncoders"] = SAMStreamLabels
 		streamLabels.write()
 
-	__gestures={
+	__gestures = {
 		"kb:f9":"connect",
 		"kb:control+f9":"connectAll",
 		"kb:f10":"disconnect",
@@ -744,7 +744,7 @@ class SPLEncoder(Encoder):
 					attempt += 1
 					if attempt%250 == 0 and self.connectionTone:
 						tones.beep(500, 50)
-						if attempt>= 500 and statChild.name == "Disconnected":
+						if attempt >= 500 and statChild.name == "Disconnected":
 							tones.beep(250, 250)
 				if connecting: continue
 			if not self.backgroundMonitor: return
@@ -759,7 +759,7 @@ class SPLEncoder(Encoder):
 		self.setFocus()
 		# Same as SAM encoders.
 		if not self.backgroundMonitor: self.connectStart(connecting=True)
-	script_connect.__doc__=_("Connects to a streaming server.")
+	script_connect.__doc__ = _("Connects to a streaming server.")
 
 	# Announce SPL Encoder columns: encoder settings and transfer rate.
 	def script_announceEncoderSettings(self, gesture):
@@ -793,7 +793,7 @@ class SPLEncoder(Encoder):
 		streamLabels["SPLEncoders"] = SPLStreamLabels
 		streamLabels.write()
 
-	__gestures={
+	__gestures = {
 		"kb:f9":"connect",
 		"kb:control+NVDA+3":"announceEncoderSettings",
 		"kb:control+NVDA+4":"announceEncoderTransfer"

--- a/site_scons/site_tools/gettexttool/__init__.py
+++ b/site_scons/site_tools/gettexttool/__init__.py
@@ -32,17 +32,17 @@ def generate(env):
 	env.SetDefault(gettext_package_name="")
 	env.SetDefault(gettext_package_version="")
 
-	env['BUILDERS']['gettextMoFile']=env.Builder(
+	env['BUILDERS']['gettextMoFile'] = env.Builder(
 		action=Action("msgfmt -o $TARGET $SOURCE", "Compiling translation $SOURCE"),
 		suffix=".mo",
 		src_suffix=".po"
 	)
 
-	env['BUILDERS']['gettextPotFile']=env.Builder(
+	env['BUILDERS']['gettextPotFile'] = env.Builder(
 		action=Action("xgettext " + XGETTEXT_COMMON_ARGS, "Generating pot file $TARGET"),
 		suffix=".pot")
 
-	env['BUILDERS']['gettextMergePotFile']=env.Builder(
+	env['BUILDERS']['gettextMergePotFile'] = env.Builder(
 		action=Action("xgettext " + "--omit-header --no-location " + XGETTEXT_COMMON_ARGS,
 			"Generating pot file $TARGET"),
 		suffix=".pot")


### PR DESCRIPTION
PYTHON_E225: 'Fix extraneous whitespace around keywords.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.